### PR TITLE
Unrecognised argument(s): logging

### DIFF
--- a/mysslgen.py
+++ b/mysslgen.py
@@ -1,15 +1,17 @@
 #!/usr/bin/python3 -tt
+import argparse
 import base64
-import os
 import io
 import logging
-import argparse
+import os
+import platform
+import stat
+import sys
+
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-import platform
-import stat
 
 # External
 from OpenSSL import crypto

--- a/mysslgen.py
+++ b/mysslgen.py
@@ -16,7 +16,7 @@ except ImportError:
 # External
 from OpenSSL import crypto
 
-logging.basicConfig(logging=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 mylog = logging.getLogger(__name__)
 mylog.setLevel(logging.DEBUG)
 

--- a/mysslgen.py
+++ b/mysslgen.py
@@ -6,7 +6,6 @@ import logging
 import os
 import platform
 import stat
-import sys
 
 try:
     import configparser


### PR DESCRIPTION
The code fails to run due to an issue with `logging.basicConfig`:
```
 ⇒ python3 mysslgen.py 
Traceback (most recent call last):
  File "mysslgen.py", line 17, in <module>
    logging.basicConfig(logging=logging.DEBUG)
  File "/usr/lib/python3.5/logging/__init__.py", line 1765, in basicConfig
    raise ValueError('Unrecognised argument(s): %s' % keys)
ValueError: Unrecognised argument(s): logging
```
It should be using `level`