### PR TITLE
Adding the ability to control the node name in the CN and extend validTo

### DIFF
--- a/mysslgen.py
+++ b/mysslgen.py
@@ -6,7 +6,6 @@ import logging
 import os
 import platform
 import stat
-import sys
 
 try:
     import configparser
@@ -23,10 +22,17 @@ mylog.setLevel(logging.DEBUG)
 parser = argparse.ArgumentParser(description='Manage SSL Certificates for MySQL')
 parser.add_argument('--config', dest='conffile', default='/etc/my.cnf')
 parser.add_argument('--ssldir', dest='ssldir', default='/etc/mysql/ssl')
+parser.add_argument('--ca-cn', dest='ca_cn', default=platform.node(), help='Set the CA name (default: %(default)s)')
+parser.add_argument('--server-cn', dest='server_cn', default=platform.node(), help='Set the server name in the CN (default: %(default)s)')
+parser.add_argument('--client-cn', dest='client_cn', default=platform.node(), help='Set the client name in the CN (default: %(default)s)')
+parser.add_argument('--valid', type=int, dest='valid_for', default=365, help='Set the number of life of the certificate (default: %(default)s days)')
 args = parser.parse_args()
 
-daysvalid = 365
+daysvalid = args.valid_for
 ssldir = args.ssldir
+ca_cn = args.ca_cn
+server_cn = args.server_cn
+client_cn = args.client_cn
 CAkeyfile = os.path.join(ssldir, 'CAkey.pem')
 CAcertfile = os.path.join(ssldir, 'CAcert.pem')
 serverkeyfile = os.path.join(ssldir, 'server-key.pem')
@@ -75,7 +81,7 @@ else:
 if not os.path.exists(CAcertfile) or os.stat(CAcertfile).st_size == 0:
     mylog.info('No or empty CA certificate file found, creating it.')
     CAcert = crypto.X509()
-    CAcert.get_subject().CN = 'MySQL CA {node}'.format(node=platform.node())
+    CAcert.get_subject().CN = 'MySQL CA {node}'.format(node=ca_cn)
     CAcert.gmtime_adj_notBefore(0)
     CAcert.gmtime_adj_notAfter(60*60*24*daysvalid)
     CAcert.set_serial_number(0x1)
@@ -131,7 +137,7 @@ else:
 if not os.path.exists(servercertfile) or os.stat(servercertfile).st_size == 0:
     mylog.info('No or empty server certificate file found, creating it.')
     servercert = crypto.X509()
-    servercert.get_subject().CN = 'MySQL Server {node}'.format(node=platform.node())
+    servercert.get_subject().CN = 'MySQL Server {node}'.format(node=server_cn)
     servercert.gmtime_adj_notBefore(0)
     servercert.gmtime_adj_notAfter(60*60*24*daysvalid)
     servercert.set_serial_number(0x2)
@@ -220,7 +226,7 @@ else:
 if not os.path.exists(clientcertfile) or os.stat(clientcertfile).st_size == 0:
     mylog.info('No or empty client certificate file found, creating it.')
     clientcert = crypto.X509()
-    clientcert.get_subject().CN = 'MySQL Server {node}'.format(node=platform.node())
+    clientcert.get_subject().CN = 'MySQL Server {node}'.format(node=client_cn)
     clientcert.gmtime_adj_notBefore(0)
     clientcert.gmtime_adj_notAfter(60*60*24*daysvalid)
     clientcert.set_serial_number(0x3)

--- a/mysslgen.py
+++ b/mysslgen.py
@@ -25,7 +25,7 @@ parser.add_argument('--ssldir', dest='ssldir', default='/etc/mysql/ssl')
 parser.add_argument('--ca-cn', dest='ca_cn', default=platform.node(), help='Set the CA name (default: %(default)s)')
 parser.add_argument('--server-cn', dest='server_cn', default=platform.node(), help='Set the server name in the CN (default: %(default)s)')
 parser.add_argument('--client-cn', dest='client_cn', default=platform.node(), help='Set the client name in the CN (default: %(default)s)')
-parser.add_argument('--valid', type=int, dest='valid_for', default=365, help='Set the number of life of the certificate (default: %(default)s days)')
+parser.add_argument('--valid', type=int, dest='valid_for', default=365, help='Set the expiry date in days (default: %(default)s days)')
 args = parser.parse_args()
 
 daysvalid = args.valid_for

--- a/mysslgen.py
+++ b/mysslgen.py
@@ -1,15 +1,17 @@
 #!/usr/bin/python3 -tt
+import argparse
 import base64
-import os
 import io
 import logging
-import argparse
+import os
+import platform
+import stat
+import sys
+
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-import platform
-import stat
 
 # External
 from OpenSSL import crypto

--- a/mysslgen.py
+++ b/mysslgen.py
@@ -16,7 +16,7 @@ except ImportError:
 # External
 from OpenSSL import crypto
 
-logging.basicConfig(logging=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 mylog = logging.getLogger(__name__)
 mylog.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
If you are generating a batch of server certificates it is likely that you will not want the current node name to be used on all certificates, as well as extend the expiry date of the certs.

```
 ⇒ ./mysslgen.py --help
usage: mysslgen.py [-h] [--config CONFFILE] [--ssldir SSLDIR] [--ca-cn CA_CN]
                   [--server-cn SERVER_CN] [--client-cn CLIENT_CN]
                   [--valid VALID_FOR]

Manage SSL Certificates for MySQL

optional arguments:
  -h, --help            show this help message and exit
  --config CONFFILE
  --ssldir SSLDIR
  --ca-cn CA_CN         Set the CA name (default: xxx)
  --server-cn SERVER_CN
                        Set the server name in the CN (default: xxx)
  --client-cn CLIENT_CN
                        Set the client name in the CN (default: xxx)
  --valid VALID_FOR     Set the expiry date in days (default:
                        365 days)
```

Here is an example:
```
 ⇒ sudo openssl x509 -noout -subject -in /etc/mysql/ssl/CAcert.pem
subject= /CN=MySQL CA xxx

 ⇒ sudo ./mysslgen.py --ca-cn=test --valid 3650

 ⇒ sudo openssl x509 -noout -subject -in /etc/mysql/ssl/CAcert.pem              
subject= /CN=MySQL CA test

 ⇒ sudo openssl x509 -noout -enddate -in /etc/mysql/ssl/CAcert.pem
notAfter=Oct  6 00:22:28 2027 GMT
```

**N.B.** this contains the fix for `logging.basicConfig` merged from https://github.com/dveeden/mysslgen/pull/8